### PR TITLE
Remove DependencyInfoBlock

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,12 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
```
$ apksigtool parse --json QuickEdit-Photo-Editor_Release-v1.1.0-4.apk | jq -r '.pairs[].value._type'
APKSignatureSchemeBlock
DependencyInfoBlock
VerityPaddingBlock
```

It's a Signing block added by AGP and encrypted with the Google public key so it can't be read by anyone else except Google. You can read more about it [here](https://gitlab.com/fdroid/admin/-/issues/367) and [here](https://gitlab.com/fdroid/fdroidserver/-/issues/1056).